### PR TITLE
refactor(api): rendre le paramètre client_id optionnel selon l'URL de la base

### DIFF
--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -32,12 +32,15 @@ class BaseAPIClient:
         service_id = api_key[-73:-37]
         api_key = api_key[-36:]
 
-        assert base_url, "Missing base url"
-        assert service_id, "Missing service ID"
-        assert api_key, "Missing API key"
+        if not base_url:
+            raise ValueError("Missing base url")
+        if not service_id:
+            raise ValueError("Missing service ID")
+        if not api_key:
+            raise ValueError("Missing API key")
 
-        if "mcn.api.gouv.qc.ca" in base_url:
-            assert client_id, "A valid client identifier (X-QC-Client-Id) is required when using the PGGAPI proxy."
+        if "mcn.api.gouv.qc.ca" in base_url and not client_id:
+            raise ValueError("A valid client identifier (X-QC-Client-Id) is required when using the PGGAPI proxy.")
 
         self.client_id = client_id
         self.base_url = base_url

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -18,9 +18,9 @@ class BaseAPIClient:
 
      Args:
         api_key (str): The combined API key used to authenticate requests to the Notification API.
-        client_id (str): A required unique identifier for the client or service making the request.
+        client_id (str or None): Optional. Required only if the proxy is MCN (PGGAPI).
     """
-    def __init__(self, api_key, client_id, base_url="https://gw-gouvqc.mcn.api.gouv.qc.ca/pgn", timeout=30):
+    def __init__(self, api_key, client_id=None, base_url="https://gw-gouvqc.mcn.api.gouv.qc.ca/pgn", timeout=30):
         """
         Initialise the client
         Error if either of base_url or secret missing
@@ -35,7 +35,9 @@ class BaseAPIClient:
         assert base_url, "Missing base url"
         assert service_id, "Missing service ID"
         assert api_key, "Missing API key"
-        assert client_id, "Missing client_id"
+
+        if "mcn.api.gouv.qc.ca" in base_url:
+            assert client_id, "A valid client identifier (X-QC-Client-Id) is required when using the PGGAPI proxy."
 
         self.client_id = client_id
         self.base_url = base_url
@@ -64,9 +66,11 @@ class BaseAPIClient:
         headers = {
             "Content-type": "application/json",
             "Authorization": f"Bearer {api_token}",
-            "User-agent": f"NOTIFY-API-PYTHON-CLIENT/{__version__}",
-            "X-QC-Client-Id": self.client_id
+            "User-agent": f"NOTIFY-API-PYTHON-CLIENT/{__version__}"
         }
+
+        if self.client_id:
+            headers["X-QC-Client-Id"] = self.client_id
 
         return headers
     

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -39,10 +39,15 @@ def test_default_timeout_is_set(base_client):
     assert base_client.timeout == 30
 
 
-def test_fails_if_client_id_missing():
-    with pytest.raises(TypeError) as err:
-        BaseAPIClient(api_key=COMBINED_API_KEY)
-    assert "missing 1 required positional argument: 'client_id'" in str(err.value)
+def test_allows_client_id_missing_if_not_mcn_url():
+    client = BaseAPIClient(api_key=COMBINED_API_KEY, base_url="https://api.example.com")
+    assert client.client_id is None
+
+
+def test_fails_if_client_id_missing_and_url_is_mcn():
+    with pytest.raises(AssertionError) as err:
+        BaseAPIClient(api_key=COMBINED_API_KEY, base_url="https://gw-gouvqc.mcn.api.gouv.qc.ca/pgn")
+    assert str(err.value) == "A valid client identifier (X-QC-Client-Id) is required when using the PGGAPI proxy."
 
 
 def test_fails_if_service_id_missing():


### PR DESCRIPTION
- Mise à jour de la classe BaseAPIClient pour que client_id soit requis uniquement
  si base_url contient "mcn.api.gouv.qc.ca".
- Ajout d'une logique conditionnelle dans __init__ pour valider client_id seulement
  pour les appels aux proxys de la PGGAPI.
- Adaptation des tests existants à cette nouvelle contrainte :
  - Modification de test_fails_if_client_id_missing pour refléter ce changement.
  - Ajout de tests dédiés :
    - test_fails_if_client_id_missing_and_url_is_mcn
    - test_allows_client_id_missing_if_not_mcn_url
- Refactorisation légère pour améliorer la lisibilité et la robustesse des assertions.